### PR TITLE
Support sync of key data supplied directly on the command line

### DIFF
--- a/cpk-tool/Cargo.lock
+++ b/cpk-tool/Cargo.lock
@@ -324,6 +324,7 @@ version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
+ "base64",
  "chrono",
  "clap 3.0.0-beta.2",
  "cpk",

--- a/cpk-tool/Cargo.toml
+++ b/cpk-tool/Cargo.toml
@@ -17,6 +17,7 @@ ring = { version = "0.16.20", optional = true }
 rsa = { version = "0.5.0", features = ["alloc"] }
 pkcs1 = { version = "0.2.3", features = ["pem"] }
 pkcs8 = { version = "0.7.5", features = ["pem"] }
+base64 = { version = "0.13.0", optional = true }
 serde = "1.0.123"
 serde_json = "1.0.64"
 sha2 = "0.9.5"
@@ -34,6 +35,6 @@ name = "cpk-tool"
 [features]
 default = [ "build", "install", "sync" ]
 build = [ "ring", "cpk/key-management" ]
-sync = [ "cpk/cpm", "cpk/key-management" ]
+sync = [ "base64", "cpk/cpm", "cpk/key-management" ]
 install = [ "cpk/cpm" ]
 cpm-simulator = [ "cpk/cpm-simulator" ]

--- a/cpk-tool/src/error.rs
+++ b/cpk-tool/src/error.rs
@@ -38,6 +38,11 @@ pub enum Error {
     /// Error emanating from the cpk-tool itself.
     #[error(transparent)]
     ToolError(#[from] ToolErrorKind),
+
+    /// Error coming from base64 string decoding, which only occurs in the sync command
+    #[error(transparent)]
+    #[cfg(feature = "sync")]
+    Base64Error(#[from] base64::DecodeError),
 }
 
 /// Errors originating in the cpk-tool itself.

--- a/cpk/src/cpm/mod.rs
+++ b/cpk/src/cpm/mod.rs
@@ -391,6 +391,7 @@ impl ConfidentialPackageManager {
 
 #[cfg(not(feature = "cpm-simulator"))]
 use std::ffi::CStr;
+#[cfg(not(feature = "cpm-simulator"))]
 #[no_mangle]
 pub fn ocall_log(msg: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     // TODO, output to somewhere more defined


### PR DESCRIPTION
New variant of the sync command that allows the caller to supply the wrapped key data directly on the command line.

Signed-off-by: Paul Howard <paul.howard@arm.com>